### PR TITLE
Add index to message on receiver_id, read_

### DIFF
--- a/modules/global/src/de/diedavids/cuba/userinbox/entity/Message.java
+++ b/modules/global/src/de/diedavids/cuba/userinbox/entity/Message.java
@@ -15,7 +15,9 @@ import java.util.Date;
 import com.haulmont.cuba.core.entity.Entity;
 
 @Listeners("ddcui_MessageEntityListener")
-@Table(name = "DDCUI_MESSAGE")
+@Table(name = "DDCUI_MESSAGE", indexes = {
+        @Index(name = "IDX_DDCUI_MESSAGE_ON_RECEIVER_ID_READ_", columnList = "RECEIVER_ID, READ_")
+})
 @javax.persistence.Entity(name = "ddcui$Message")
 public class Message extends StandardEntity {
     private static final long serialVersionUID = -631256156050655713L;


### PR DESCRIPTION
As discussed on the forum, the countUnreadMessagesForCurrentUser() method polls the DB by receiver_id and read_ in order to get said count.  But there is currently no index to make that query perform well, so... adding it would be a good idea.
