### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ public class CustomApplicationMainScreen extends MainScreen {
     }
 
     @Subscribe
-    protected void onAfterShow(AfterShowEvent event) {
+    protected void onAfterInit(AfterInit event) {
         userInboxMessageMenuBadge.updateMessageCounter(sideMenu);
     }
 


### PR DESCRIPTION
Subscribing to AfterShow event prevents a default set screen from opening automatically upon logging in.