### PR TITLE
Fix style for badge

### DIFF
--- a/modules/web/src/de/diedavids/cuba/userinbox/web/screens/UserInboxMessageMenuBadge.java
+++ b/modules/web/src/de/diedavids/cuba/userinbox/web/screens/UserInboxMessageMenuBadge.java
@@ -39,6 +39,7 @@ public class UserInboxMessageMenuBadge {
                         .withScreenClass(UserInbox.class)
                         .show()
         );
+        messagesMenuItem.setStyleName("messages-item");
 
         sideMenu.addMenuItem(messagesMenuItem, 0);
 
@@ -53,14 +54,17 @@ public class UserInboxMessageMenuBadge {
     }
 
     public void updateMessageCounter(SideMenu sideMenu) {
-        sideMenu.getMenuItemNN("messages")
-                .setBadgeText(
-                        messages.formatMainMessage("menu-config.ddcui$user-inbox.badge", getMessageCounter())
-                );
+        final long messageCounter = getMessageCounter();
+        final SideMenu.MenuItem messagesItem = sideMenu.getMenuItemNN("messages");
+        messagesItem.setBadgeText(
+                this.messages.formatMainMessage("menu-config.ddcui$user-inbox.badge", messageCounter)
+        );
+        if (messageCounter == 0)
+            messagesItem.removeStyleName("new-messages");
+        else messagesItem.addStyleName("new-messages");
     }
 
     private long getMessageCounter() {
         return messageService.countUnreadMessagesForCurrentUser();
     }
-
 }

--- a/modules/web/src/de/diedavids/cuba/userinbox/web/screens/main/UserInboxSideMenuMainScreen.java
+++ b/modules/web/src/de/diedavids/cuba/userinbox/web/screens/main/UserInboxSideMenuMainScreen.java
@@ -6,6 +6,8 @@ import com.haulmont.cuba.gui.screen.Subscribe;
 import com.haulmont.cuba.gui.screen.UiController;
 import com.haulmont.cuba.gui.screen.UiDescriptor;
 import com.haulmont.cuba.web.app.main.MainScreen;
+import com.haulmont.cuba.web.gui.screen.ScreenDependencyUtils;
+import com.vaadin.ui.Dependency;
 import de.diedavids.cuba.userinbox.web.screens.UserInboxMessageMenuBadge;
 
 import javax.inject.Inject;
@@ -30,6 +32,8 @@ public class UserInboxSideMenuMainScreen extends MainScreen {
                 updateCountersTimer,
                 this
         );
+
+        loadStyles();
     }
 
     @Subscribe
@@ -42,4 +46,8 @@ public class UserInboxSideMenuMainScreen extends MainScreen {
         userInboxMessageMenuBadge.updateMessageCounter(sideMenu);
     }
 
+    protected void loadStyles() {
+        ScreenDependencyUtils.addScreenDependency(this,
+                "vaadin://user-inbox-main-menu-screen/messages-badge.css", Dependency.Type.STYLESHEET);
+    }
 }

--- a/modules/web/web/VAADIN/user-inbox-main-menu-screen/messages-badge.css
+++ b/modules/web/web/VAADIN/user-inbox-main-menu-screen/messages-badge.css
@@ -1,0 +1,11 @@
+.messages-item.c-sidemenu-item .c-sidemenu-item-caption .c-sidemenu-item-badge {
+    padding: 2px 5px;
+    top: unset;
+    height: 100%;
+    position: relative;
+    right: -70px;
+}
+.messages-item.new-messages .v-icon,
+.messages-item.new-messages .c-sidemenu-item-thumbnail-icon {
+    color: #7ba8cb;
+}


### PR DESCRIPTION
* How it looks like before:
![image](https://user-images.githubusercontent.com/15674660/85845274-a9d83c00-b7ac-11ea-9cb4-3d64d3650821.png)

* New style for the badge and icon color (only when there is a new messages):
![new_messages_open](https://user-images.githubusercontent.com/15674660/85844683-d0e23e00-b7ab-11ea-8ba4-b279568719c0.JPG)
* Icon color when panel is collapsed and there is a new messages:
![new_messages_closed](https://user-images.githubusercontent.com/15674660/85844856-0f77f880-b7ac-11ea-95f7-ea9e3cf74273.JPG)


